### PR TITLE
Prevent loading of custom footer on content migrations page

### DIFF
--- a/global.js
+++ b/global.js
@@ -2,11 +2,15 @@
 $(document).ready(function(e) {
   var copyYear = new Date().getFullYear();
 
-  var harvardCopy = '<div>Copyright &copy; 2014-' + copyYear + ' The President and Fellows of Harvard College <span aria-hidden="true">|</span> &nbsp</div>';
-  harvardCopy += '<p><a href="https://harvard.service-now.com/ithelp?id=kb_article&sys_id=9d718485db0d57cc83a2f3f7bf961902" id="acceptable_use_policy_link" target="_blank">Acceptable Use Policy</a> <span aria-hidden="true">|</span> ';
-  harvardCopy += '<a href="https://accessibility.huit.harvard.edu/digital-accessibility-policy" id="accessibility_link" target="_blank">Accessibility</a> <span aria-hidden="true">|</span> ';
-  harvardCopy += '<a href="https://harvard.service-now.com/ithelp?id=kb_article&sys_id=3373044ddb4d57cc83a2f3f7bf961909" id="privacy_policy_link" target="_blank">Privacy Policy</a></p>';
-  $('footer').html(harvardCopy);
+  var currentPage = window.location.pathname;
+  var isContentMigrationPage = currentPage.match(/\/courses\/\d+\/content_migrations.*/);
+  if (!isContentMigrationPage) {
+    var harvardCopy = '<div>Copyright &copy; 2014-' + copyYear + ' The President and Fellows of Harvard College <span aria-hidden="true">|</span> &nbsp</div>';
+    harvardCopy += '<p><a href="https://harvard.service-now.com/ithelp?id=kb_article&sys_id=9d718485db0d57cc83a2f3f7bf961902" id="acceptable_use_policy_link" target="_blank">Acceptable Use Policy</a> <span aria-hidden="true">|</span> ';
+    harvardCopy += '<a href="https://accessibility.huit.harvard.edu/digital-accessibility-policy" id="accessibility_link" target="_blank">Accessibility</a> <span aria-hidden="true">|</span> ';
+    harvardCopy += '<a href="https://harvard.service-now.com/ithelp?id=kb_article&sys_id=3373044ddb4d57cc83a2f3f7bf961909" id="privacy_policy_link" target="_blank">Privacy Policy</a></p>';
+    $('footer').html(harvardCopy);
+  }
 
   $("div.ic-Login-header__links > a#register_link").remove();
 


### PR DESCRIPTION
Resolves[ TLT-4723](https://at-harvard.atlassian.net/browse/TLT-4723).

Example of updated theme without custom footer:

<img width="1789" alt="Screen Shot 2024-07-23 at 3 23 32 PM" src="https://github.com/user-attachments/assets/98f5c8b8-cdf8-4b89-9861-d4a27e689ec6">
