### PR TITLE
TLT-4723: Prevent loading of accessibility footer on Content MIgration page

### DIFF
--- a/global.js
+++ b/global.js
@@ -14,6 +14,11 @@ $(document).ready(function(e) {
             return;
         }
 
+        // Do not add footer content on content migration page.
+        if (window.location.href.match(/\/courses\/\d+\/content_migrations.*/)) {
+            return;
+        }
+
         const copyYear = new Date().getFullYear();
 
         const harvardCopy =


### PR DESCRIPTION
Resolves[ TLT-4723](https://at-harvard.atlassian.net/browse/TLT-4723).

Tested in the ExEd Beta instance.

Example of updated theme without custom footer:

<img width="1789" alt="Screen Shot 2024-07-23 at 3 23 32 PM" src="https://github.com/user-attachments/assets/98f5c8b8-cdf8-4b89-9861-d4a27e689ec6">