### PR TITLE
Update login screen for Cirrus / Okta cutover

### DIFF
--- a/global.css
+++ b/global.css
@@ -15,6 +15,10 @@ div.ic-Login__content {
     color: white;
 }
 
+.hu-help-icon {
+    float: right;
+}
+
 .hu-hkey-login {
     border-top: 1px solid black;
     padding-top: 1em;
@@ -26,10 +30,6 @@ div.ic-Login__content {
 
 .hu-hkey-login-link {
     border-bottom: 1px solid black;
-}
-
-.hu-help-icon {
-    float: right;
 }
 
 .hu-hkey-help {
@@ -46,6 +46,29 @@ div.ic-Login__content {
     padding-left: 4px;
     vertical-align: baseline;
 }
+
+.hu-guest-login {
+    border-top: 1px solid black;
+    padding-top: 1em;
+    padding-bottom: .5em;
+    font-weight: bold;
+    color: black;
+    font-size: 1.25em;
+}
+
+.hu-guest-login-link {
+    border-bottom: 1px solid black;
+}
+
+.hu-guest-help {
+    display: none;
+    color: black;
+}
+
+.hu-guest-login a:hover {
+    text-decoration: none;
+}
+
 
 .ic-Login__container footer {
     font-size: .75em;

--- a/global.css
+++ b/global.css
@@ -20,9 +20,7 @@ div.ic-Login__content {
 }
 
 .hu-hkey-login {
-    border-top: 1px solid black;
-    padding-top: 1em;
-    padding-bottom: .5em;
+    padding-top: .5em;
     font-weight: bold;
     color: black;
     font-size: 1.25em;
@@ -48,8 +46,6 @@ div.ic-Login__content {
 }
 
 .hu-guest-login {
-    border-top: 1px solid black;
-    padding-top: 1em;
     padding-bottom: .5em;
     font-weight: bold;
     color: black;
@@ -69,6 +65,19 @@ div.ic-Login__content {
     text-decoration: none;
 }
 
+.other-logins {
+    border-top: 1px solid black;
+    color: black;
+    font-weight: bold;
+    font-size: 1.25em;
+    padding-top: .5em;
+}
+
+.or {
+    color: black;
+    font-weight: bold;
+    font-size: 1.25em;
+}
 
 .ic-Login__container footer {
     font-size: .75em;

--- a/global.js
+++ b/global.js
@@ -56,8 +56,9 @@ $(document).ready(function(e) {
 
   var login_body = $(".ic-Login__body").html();
   var hkey_link = `
+    <p class="other-logins">Other login options:</p>
     <div class="hu-hkey-login">
-    Or, <a href="/login/saml" class="hu-hkey-login-link">log in with <img class="hu-hkey-logo" src="https://tlt-static-prod.s3.us-east-1.amazonaws.com/images/HarvardKeyLogo.png" alt="Harvard Key"/></a>
+    <a href="/login/saml" class="hu-hkey-login-link">Log in with <img class="hu-hkey-logo" src="https://tlt-static-prod.s3.us-east-1.amazonaws.com/images/HarvardKeyLogo.png" alt="Harvard Key"/></a>
     <span class="hu-help-icon"><a href="#" onclick="$('.hu-hkey-help').toggle();"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" role="img" focusable="false" aria-label="Help for HarvardKey login">
     <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
     <path d="M5.255 5.786a.237.237 0 0 0 .241.247h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286zm1.557 5.763c0 .533.425.927 1.01.927.609 0 1.028-.394 1.028-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94z"/>
@@ -71,9 +72,9 @@ $(document).ready(function(e) {
     If you don't already have a HarvardKey, please continue to log in above with your email and password.
     </p>
     </div>
-
+    <p class="or">or</p>
     <div class="hu-guest-login">
-    Or, <a href="/login/guest" class="hu-guest-login-link">log in as a Harvard Guest</a>
+    <a href="/login/guest" class="hu-guest-login-link">Log in as a Harvard Guest</a>
     <span class="hu-help-icon"><a href="#" onclick="$('.hu-guest-help').toggle();"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" role="img" focusable="false" aria-label="Help for Harvard Guest login">
     <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
     <path d="M5.255 5.786a.237.237 0 0 0 .241.247h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286zm1.557 5.763c0 .533.425.927 1.01.927.609 0 1.028-.394 1.028-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94z"/>

--- a/global.js
+++ b/global.js
@@ -71,8 +71,27 @@ $(document).ready(function(e) {
     If you don't already have a HarvardKey, please continue to log in above with your email and password.
     </p>
     </div>
+
+    <div class="hu-guest-login">
+    Or, <a href="/login/guest" class="hu-guest-login-link">log in as a Harvard Guest</a>
+    <span class="hu-help-icon"><a href="#" onclick="$('.hu-guest-help').toggle();"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" role="img" focusable="false" aria-label="Help for Harvard Guest login">
+    <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
+    <path d="M5.255 5.786a.237.237 0 0 0 .241.247h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286zm1.557 5.763c0 .533.425.927 1.01.927.609 0 1.028-.394 1.028-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94z"/>
+    </svg></a></span>
+    </div>
+    <div class="hu-guest-help">
+    <p>
+    If you have a Harvard Guest account, you can use the link above to log in to Canvas.
+    </p>
+    <p>
+    If you don't already have a Harvard Guest account, please continue to log in above with your email and password.
+    </p>
+    </div>
   `;
+
+
   $(".ic-Login__body").append(hkey_link);
+
 
   // for mobile:
   $('div.enrollment_link a#register_link').parent().html(hkey_link);

--- a/global.js
+++ b/global.js
@@ -58,7 +58,7 @@ $(document).ready(function(e) {
   var hkey_link = `
     <p class="other-logins">Other login options:</p>
     <div class="hu-hkey-login">
-    <a href="/login/saml" class="hu-hkey-login-link">Log in with <img class="hu-hkey-logo" src="https://tlt-static-prod.s3.us-east-1.amazonaws.com/images/HarvardKeyLogo.png" alt="Harvard Key"/></a>
+    <a href="/login/saml/207" class="hu-hkey-login-link">Log in with <img class="hu-hkey-logo" src="https://static.tlt.harvard.edu/images/HarvardKeyLogo.png" alt="Harvard Key"/></a>
     <span class="hu-help-icon"><a href="#" onclick="$('.hu-hkey-help').toggle();"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" role="img" focusable="false" aria-label="Help for HarvardKey login">
     <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
     <path d="M5.255 5.786a.237.237 0 0 0 .241.247h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286zm1.557 5.763c0 .533.425.927 1.01.927.609 0 1.028-.394 1.028-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94z"/>
@@ -74,7 +74,7 @@ $(document).ready(function(e) {
     </div>
     <p class="or">or</p>
     <div class="hu-guest-login">
-    <a href="/login/guest" class="hu-guest-login-link">Log in as a Harvard Guest</a>
+    <a href="/login/saml/206" class="hu-guest-login-link">Log in as a Harvard Guest</a>
     <span class="hu-help-icon"><a href="#" onclick="$('.hu-guest-help').toggle();"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" role="img" focusable="false" aria-label="Help for Harvard Guest login">
     <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
     <path d="M5.255 5.786a.237.237 0 0 0 .241.247h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286zm1.557 5.763c0 .533.425.927 1.01.927.609 0 1.028-.394 1.028-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94z"/>


### PR DESCRIPTION
This PR updates the ExEd login screen in conjunction with changes to the HarvardKey authentication system. 

With this theme change, there are now two Harvard login options that appear below the native Canvas login form: 

* Log in with HarvardKey, which links to the new Okta IdP 
* Log in as a Harvard Guest, which links to the new Cirrus IdP

<img width="439" alt="image" src="https://github.com/user-attachments/assets/8edf9cf0-a4a5-4efc-9476-33c33877f477" />
