### PR TITLE
No footer on assignments pages

### DIFF
--- a/global.js
+++ b/global.js
@@ -19,6 +19,11 @@ $(document).ready(function(e) {
             return;
         }
 
+        // Do not add footer content on assignments pages.
+        if (window.location.href.match(/\/courses\/\d+\/assignments.*/)) {
+            return;
+        }
+
         const copyYear = new Date().getFullYear();
 
         const harvardCopy =


### PR DESCRIPTION
Our custom footer is causing display problems on some assignments pages. This PR removes the footer from assignments pages.