### PR TITLE
Remove link to DIB from theming

### DIFF
--- a/global.js
+++ b/global.js
@@ -156,10 +156,7 @@ function initAddPronounText() {
       language is constantly evolving and members of our community \
       should be able to be called and describe their identity \
       however they choose, so we are working to enable that option \
-      within Canvas. To learn more about gender, identity, \
-      or pronouns and to provide feedback, visit: \
-      <a href=\"https://dib.harvard.edu/gender-pronouns\" target=\"_blank\">\
-      https://dib.harvard.edu/gender-pronouns</a>.\
+      within Canvas.\
       ");
 
       $( "#pronouns" ).parent().parent().children("th").css("vertical-align", "top");


### PR DESCRIPTION
Remove link to DIB from theming

Deployed in dev ExEd Canvas (See here: https://harvard-catalog-courses.beta.instructure.com/profile/settings)