### PR TITLE
Fix JS + S3 Hostname

### DIFF
--- a/global.css
+++ b/global.css
@@ -86,7 +86,7 @@ div.ic-Login__content {
 
 .mobileLogin-Header {
     z-index: 1;
-    background-image: url(https://tlt-static-prod.s3.us-east-1.amazonaws.com/canvas_exed/login_screen_login_logo.png) !important;
+    background-image: url(https://static.tlt.harvard.edu/canvas_exed/login_screen_login_logo.png) !important;
     background-position: center;
     background-repeat: no-repeat;
     background-size: 300px 108px;

--- a/global.js
+++ b/global.js
@@ -99,8 +99,10 @@ $(document).ready(function(e) {
   $(".ic-Login__body").append(hkey_link);
 
 
-  // for mobile:
-  $('div.enrollment_link a#register_link').parent().html(hkey_link);
+  // for mobile login page
+  if ($('#f1_card #login_form').length > 0 && $('.ic-Login__body').length === 0) {
+    $('#login_form .forgotBlock').after(hkey_link);
+  }
 
 });
 


### PR DESCRIPTION
This PR:
- Tweaks the JS to fix an issue where the HarvardKey + Harvard Guest login options failed to load
- Updates the hostname for the S3 bucket containing the Harvard logo